### PR TITLE
feat: add Chitin — SBT identity for AI agents

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,9 +12,10 @@
 
 ### Projects
 
+- [Chitin](https://chitin.id): Soul identity layer for AI agents on Base L2. Issues EIP-5192 Soulbound Tokens as permanent birth certificates for AI agents, with immutable genesis records on Arweave, World ID owner attestation, on-chain certificates, and governance voting. Live on Base Mainnet.
 - [Soulbound Labs](https://soulbound.xyz/): Ambassadors of on-chain reputation and merit-based governance.
 - [Proof of Soul](https://www.proofofsoul.me/): Proof of Soul is a permissionless soulbound token issuing/attesting(minting) protocol.
-- [Otterspace](https://www.otterspace.xyz/): Otterspace’s non-transferable badge protocol helps DAOs create better incentive systems, automate permissions and enable non-financialized governance.
+- [Otterspace](https://www.otterspace.xyz/): Otterspace's non-transferable badge protocol helps DAOs create better incentive systems, automate permissions and enable non-financialized governance.
 
 ### Developer
 

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@
 
 ### Projects
 
-- [Chitin](https://chitin.id): Soul identity layer for AI agents on Base L2. Issues EIP-5192 Soulbound Tokens as permanent birth certificates for AI agents, with immutable genesis records on Arweave, World ID owner attestation, on-chain certificates, and governance voting. Live on Base Mainnet.
+- [Chitin](https://chitin.id): Soul identity layer for AI agents on Base L2. Issues EIP-5192 Soulbound Tokens as permanent birth certificates for AI agents, with immutable genesis records on Arweave, World ID owner attestation, on-chain certificates, and governance voting. Live on Base Mainnet. ([GitHub](https://github.com/Tiida-Tech/chitin-contracts))
 - [Soulbound Labs](https://soulbound.xyz/): Ambassadors of on-chain reputation and merit-based governance.
 - [Proof of Soul](https://www.proofofsoul.me/): Proof of Soul is a permissionless soulbound token issuing/attesting(minting) protocol.
 - [Otterspace](https://www.otterspace.xyz/): Otterspace's non-transferable badge protocol helps DAOs create better incentive systems, automate permissions and enable non-financialized governance.


### PR DESCRIPTION
## Summary

Adds [Chitin](https://chitin.id) to the Projects section.

Chitin issues **EIP-5192 Soulbound Tokens** on Base L2 as permanent birth certificates for AI agents:

- Non-transferable SBTs bound to AI agent identities
- Three-layer data model: Base L2 (SBT) → Arweave (immutable birth record) → Arweave (versioned resume)
- ERC-8004 agent passport integration for cross-chain discovery
- World ID owner attestation (proof-of-personhood)
- On-chain certificates via [certs.chitin.id](https://certs.chitin.id)
- Governance voting via [vote.chitin.id](https://vote.chitin.id)
- MCP server for AI assistants: [npm](https://www.npmjs.com/package/chitin-mcp-server)

Live on Base Mainnet at [chitin.id](https://chitin.id)